### PR TITLE
Change error handling in database calls 

### DIFF
--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -813,3 +813,11 @@ class WPMweConnectTest(unittest.TestCase):
             prep="vor",
         )
         self.assertEqual(result[0], expected)
+
+    def test_invalid_id_returns_none(self):
+        self.assertIsNone(self.mwe_connector.get_relation_by_id(42))
+
+    def test_logging_for_invalid_id(self):
+        with self.assertLogs() as logged:
+            self.mwe_connector.get_relation_by_id(42)
+            assert "Invalid Id: 42" in logged.output[0]

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -649,6 +649,15 @@ class WPConnectTest(unittest.TestCase):
         ]
         self.assertEqual(result, [(307, "Feuerwehr", "GMOD", "Stadt")])
 
+    def test_invalid_id_returns_none(self):
+        with self.assertLogs() as logged:
+            self.assertIsNone(self.connector.get_relation_by_id(42))
+            assert "Invalid Id: 42" in logged.output[0]
+
+    def test_invalid_id_returns_empty_list_of_concordances(self):
+        result = self.connector.get_concordances(42, 0, 10)
+        self.assertEqual(result, [])
+
 
 class WPMweConnectTest(unittest.TestCase):
     @classmethod

--- a/tests/test_wp.py
+++ b/tests/test_wp.py
@@ -47,7 +47,7 @@ class MockDb:
         }
 
     def get_relation_by_id(self, coocc_id, is_mwe=False):
-        return self.db[coocc_id]
+        return self.db.get(coocc_id)
 
     def get_lemma_and_pos(self, lemma, pos):
         return [
@@ -815,3 +815,9 @@ class WordprofileTest(unittest.TestCase):
             "data": {},
         }
         self.assertEqual(result, expected)
+
+    def test_invalid_id_returns_empty_dict(self):
+        result = self.wp.get_relation_by_info_id(234, is_mwe=False)
+        mwe_result = self.wp.get_relation_by_info_id(1001, is_mwe=True)
+        self.assertEqual(result, {})
+        self.assertEqual(mwe_result, {})

--- a/tests/test_wp.py
+++ b/tests/test_wp.py
@@ -803,3 +803,15 @@ class WordprofileTest(unittest.TestCase):
             result,
             [{"Lemma": "plüschig", "Score": 200}, {"Lemma": "gemütlich", "Score": 20}],
         )
+
+    def test_empty_id_list_returns_empty_data(self):
+        result = self.wp.get_mwe_relations([])
+        self.assertEqual(result, {"parts": [], "data": {}})
+
+    def test_collocations_skipped_if_not_in_passed_relations(self):
+        result = self.wp.get_mwe_relations([14], relations=["GMOD"])
+        expected = {
+            "parts": [{"Lemma": "Grammatik"}, {"Lemma": "lateinisch"}],
+            "data": {},
+        }
+        self.assertEqual(result, expected)

--- a/wordprofile/errors.py
+++ b/wordprofile/errors.py
@@ -1,2 +1,0 @@
-class InternalError(Exception):
-    pass

--- a/wordprofile/wp.py
+++ b/wordprofile/wp.py
@@ -454,6 +454,8 @@ class Wordprofile:
             coocc_info = self.db_mwe.get_relation_by_id(int(coocc_id))
         else:
             coocc_info = self.db.get_relation_by_id(int(coocc_id))
+        if coocc_info is None:
+            return {}
         relation_identifier = coocc_info.rel
         if coocc_info.inverse:
             relation_identifier = f"~{relation_identifier}"

--- a/wordprofile/wp.py
+++ b/wordprofile/wp.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Union
 
 import wordprofile.config
 import wordprofile.formatter as formatting
-from wordprofile.errors import InternalError
+from wordprofile.datatypes import Coocc
 from wordprofile.utils import tag_f2b
 from wordprofile.wpse.connector import WPConnect
 from wordprofile.wpse.mwe_connector import WPMweConnect
@@ -344,7 +344,7 @@ class Wordprofile:
         self,
         lemma1: str,
         lemma2: str,
-        diffs,
+        diffs: list[Coocc],
         number: int,
         use_intersection: bool,
         operation: str,
@@ -386,12 +386,12 @@ class Wordprofile:
             elif c.lemma1 == lemma2:
                 collocation_diffs[c.lemma2]["coocc_2"] = c
                 collocation_diffs[c.lemma2]["pos"] = c.tag1
-            elif c.lemma1.lower() in {lemma1.lower(), lemma2.lower()}:
-                continue
             else:
-                raise InternalError(
-                    f"Unexpected lemma {c} for Lemma1 ({lemma1}) and Lemma2 ({lemma2})"
+                logger.warning(
+                    "Unexpected lemma %s from collocation %d for lemma pair (%s, %s)."
+                    % (c.lemma1, c.id, lemma1, lemma2)
                 )
+                continue
         # for intersection, only a subset is used further
         if use_intersection:
             diffs_grouped = [

--- a/wordprofile/wpse/connector.py
+++ b/wordprofile/wpse/connector.py
@@ -1,11 +1,10 @@
 import logging
-from typing import List
+from typing import List, Optional
 
 import pymysql
 
 import wordprofile.config
 from wordprofile.datatypes import Concordance, Coocc, LemmaInfo
-from wordprofile.errors import InternalError
 from wordprofile.utils import split_relation_inversion
 
 pymysql.install_as_MySQLdb()
@@ -95,6 +94,8 @@ class WPConnect:
             List of Concordance.
         """
         coocc_info = self.get_relation_by_id(coocc_id)
+        if coocc_info is None:
+            return []
         if coocc_info.inverse:
             head_lemma, head_tag = coocc_info.lemma2, coocc_info.tag2
             dep_lemma, dep_tag = coocc_info.lemma1, coocc_info.tag1
@@ -214,7 +215,7 @@ class WPConnect:
             )
         )
 
-    def get_relation_by_id(self, coocc_id: int, min_freq: int = 1) -> Coocc:
+    def get_relation_by_id(self, coocc_id: int, min_freq: int = 1) -> Optional[Coocc]:
         """Fetches collocation information for collocation id from database backend.
 
         Args:
@@ -237,14 +238,12 @@ class WPConnect:
         """
         res = self.__fetchall(query, (min_freq, abs(coocc_id)))
         if len(res) == 0:
-            raise ValueError("Invalid Id")
-        elif len(res) > 1:
-            raise InternalError(f"Too many results for coocc id {coocc_id}.")
-        else:
-            result = Coocc(*res[0])
-            if coocc_id < 0:
-                return self._invert_coocc(result)
-            return result
+            logger.info("Invalid Id: %d" % coocc_id)
+            return None
+        result = Coocc(*res[0])
+        if coocc_id < 0:
+            return self._invert_coocc(result)
+        return result
 
     def _invert_coocc(self, coocc: Coocc) -> Coocc:
         coocc.inverse = 1


### PR DESCRIPTION
* Changed handling of queries for invalid ids to return `None` instead of raising an error if requested collocation/MWE id is not in database
* Wordprofile now returns empty list/dictionary if database contains no results for requested id