### PR TITLE
feat: retrieve POS tag for reduced profile query

### DIFF
--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -275,22 +275,26 @@ class WPConnectTest(unittest.TestCase):
 
     def test_retrieval_of_collocates_order_by_logdice(self):
         result = [
-            (col[0], round(col[1], 2))
+            (col[0], col[1], round(col[2], 2))
             for col in self.connector.get_collocates(
                 "Feuerwehr", "NOUN", order_by="log_dice"
             )
         ]
         expected = [
-            ("nehmen", 8.25),
-            ("Angabe", 7.25),
-            ("Stadt", 7.15),
-            ("Sprecher", 7.05),
+            ("nehmen", "VERB", 8.25),
+            ("Angabe", "NOUN", 7.25),
+            ("Stadt", "NOUN", 7.15),
+            ("Sprecher", "NOUN", 7.05),
         ]
         self.assertEqual(result, expected)
 
     def test_retrieval_of_collocates_order_by_freq(self):
         result = self.connector.get_collocates("Kunst", "NOUN", order_by="frequency")
-        expected = [("Haus", 389), ("Kultur", 51), ("schön", 42)]
+        expected = [
+            ("Haus", "NOUN", 389),
+            ("Kultur", "NOUN", 51),
+            ("schön", "ADJ", 42),
+        ]
         self.assertEqual(result, expected)
 
     def test_retrieval_of_collocates_cutoff(self):
@@ -298,9 +302,9 @@ class WPConnectTest(unittest.TestCase):
             "nehmen", "VERB", order_by="frequency", number=3
         )
         expected = [
-            ("fest", 387),
-            ("Angabe", 386),
-            ("Polizei", 262),
+            ("fest", "ADP", 387),
+            ("Angabe", "NOUN", 386),
+            ("Polizei", "NOUN", 262),
         ]
         self.assertEqual(result, expected)
 
@@ -312,16 +316,16 @@ class WPConnectTest(unittest.TestCase):
         result = self.connector.get_collocates(
             "liegen", "VERB", order_by="frequency", min_freq=200
         )
-        self.assertEqual(result, [("Boden", 210)])
+        self.assertEqual(result, [("Boden", "NOUN", 210)])
 
     def test_collocates_filtered_by_logdice(self):
         result = [
-            (col[0], round(col[1], 1))
+            (col[0], col[1], round(col[2], 1))
             for col in self.connector.get_collocates(
                 "nehmen", "VERB", order_by="log_dice", min_stat=10.0
             )
         ]
-        self.assertEqual(result, [("Angabe", 11.0), ("fest", 10.9)])
+        self.assertEqual(result, [("Angabe", "NOUN", 11.0), ("fest", "ADP", 10.9)])
 
     def test_get_lemma_and_pos_no_inverse(self):
         result = self.connector.get_lemma_and_pos(lemma="liegen", lemma_tag="VERB")
@@ -422,7 +426,7 @@ class WPConnectTest(unittest.TestCase):
 
     def test_retrieval_of_inverse_collocates(self):
         result = self.connector.get_collocates("Polizei", "NOUN", order_by="frequency")
-        expected = [("nehmen", 262)]
+        expected = [("nehmen", "VERB", 262)]
         self.assertEqual(result, expected)
 
     def test_get_lemma_and_pos_without_pos(self):
@@ -572,8 +576,8 @@ class WPConnectTest(unittest.TestCase):
     def test_collocates_exclude_KON_relation_if_target_is_collocate(self):
         result = self.connector.get_collocates("Kultur", "NOUN", order_by="frequency")
         expected = [
-            ("Festival", 25),
-            ("modern", 20),
+            ("Festival", "NOUN", 25),
+            ("modern", "ADJ", 20),
         ]
         self.assertEqual(result, expected)
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -734,6 +734,6 @@ def test_page_replaced_with_dash():
 
 
 def test_format_collocate():
-    collocate = ("Collocate1", 10)
+    collocate = ("Collocate1", "Tag1", 10)
     result = form.format_collocate(collocate)
-    assert result == {"Lemma": "Collocate1", "Score": 10}
+    assert result == {"Lemma": "Collocate1", "Score": 10, "POS": "Tag1"}

--- a/tests/test_wp.py
+++ b/tests/test_wp.py
@@ -79,8 +79,8 @@ class MockDb:
             if coocc.lemma1 == lemma and coocc.tag1 == lemma_tag:
                 if coocc.freq >= min_freq and coocc.score >= min_stat:
                     score = coocc.score if order_by == "log_dice" else coocc.freq
-                    collocates.append((coocc.lemma2, score))
-        return sorted(collocates, key=lambda x: x[1], reverse=True)[:number]
+                    collocates.append((coocc.lemma2, coocc.tag2, score))
+        return sorted(collocates, key=lambda x: x[2], reverse=True)[:number]
 
 
 class MockMweDb(MockDb):
@@ -788,11 +788,10 @@ class WordprofileTest(unittest.TestCase):
             col["Score"] = round(score, 1)
             result.append(col)
         expected = [
-            {"Lemma": "Kommandant", "Score": 8.5},
-            {"Lemma": "rücken", "Score": 8.5},
-            {"Lemma": "Umgebung", "Score": 4.8},
+            {"Lemma": "Kommandant", "POS": "NOUN", "Score": 8.5},
+            {"Lemma": "rücken", "POS": "VERB", "Score": 8.5},
+            {"Lemma": "Umgebung", "POS": "NOUN", "Score": 4.8},
         ]
-
         self.assertEqual(result, expected)
 
     def test_reduced_profile_order_by_freq(self):
@@ -801,7 +800,10 @@ class WordprofileTest(unittest.TestCase):
         )
         self.assertEqual(
             result,
-            [{"Lemma": "plüschig", "Score": 200}, {"Lemma": "gemütlich", "Score": 20}],
+            [
+                {"Lemma": "plüschig", "POS": "ADJ", "Score": 200},
+                {"Lemma": "gemütlich", "POS": "ADJ", "Score": 20},
+            ],
         )
 
     def test_empty_id_list_returns_empty_data(self):

--- a/wordprofile/formatter.py
+++ b/wordprofile/formatter.py
@@ -195,5 +195,5 @@ def format_lemma_with_preposition(lemma: str, preposition: str, inverse: int) ->
 def format_collocate(
     collocate: tuple[str, int | float],
 ) -> dict[str, str | int | float]:
-    lemma, score = collocate
-    return {"Lemma": lemma, "Score": score}
+    lemma, tag, score = collocate
+    return {"Lemma": lemma, "Score": score, "POS": tag}

--- a/wordprofile/wpse/connector.py
+++ b/wordprofile/wpse/connector.py
@@ -391,13 +391,13 @@ class WPConnect:
         Fetch only collocates and metrics (logDice or frequency) for target
         lemma from all relations.
 
-        The result is a list of tuples (collocate, score) sorted by the
-        retrieved metric in descending order. Collocations are filtered
-        by frequency and logDice score.
+        The result is a list of tuples (collocate, pos, score) sorted by
+        the retrieved metric in descending order. Collocations are
+        filtered by frequency and logDice score.
         N.B.: The look-up of collocates is relation-agnostic and returns
-        only the lemma of the collocate. I.e. the same lemma might appear
-        more than once with different scores because they originate from
-        different relations or are differentiated by their preposition.
+        only the lemma and pos of the collocate. I.e. the same lemma might
+        appear more than once with different scores because they originate
+        from different relations or are differentiated by their preposition.
 
         Args:
             lemma:      Target lemma.
@@ -417,7 +417,14 @@ class WPConnect:
                 THEN c.lemma2
             WHEN %(lemma)s = c.lemma2
                 THEN c.lemma1
-          END AS lemma, IFNULL(c.{metric}, 0) as metric
+          END AS lemma,
+          CASE
+            WHEN %(lemma)s = c.lemma1
+                THEN c.lemma2_tag
+            WHEN %(lemma)s = c.lemma2
+                THEN c.lemma1_tag
+          END AS pos,
+          IFNULL(c.{metric}, 0) as metric
         FROM collocations c
         WHERE
           (


### PR DESCRIPTION
Queries to `/api/v1/profile` endpoint with parameter `reduced=true` now also return POS tag of collocate.
E.g. query for 'Haus' returns:

  ``[{
    "Lemma": "verlassen",
    "Score": 8.621187210083008,
    "POS": "VERB"
  },
  {
    "Lemma": "Kunst",
    "Score": 8.407368659973145,
    "POS},
...
]``